### PR TITLE
CI: don't run make check on flint and antic

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -34,9 +34,9 @@ jobs:
     - name: Install autotools
       run: brew update && brew install autoconf automake libtool
     - name: Install flint
-      run:  cd flint2 && ./configure && make && make check && make install && cd ..
+      run:  cd flint2 && ./configure && make && make install && cd ..
     - name: Install antic
-      run: cd antic && ./configure && make && make install && make check && cd ..
+      run: cd antic && ./configure && make && make install && cd ..
     - name: Install carat
       run: cd carat && ./autogen.sh && ./configure && make && make install && cp libfunctions.a /usr/local/lib && cd ..
     - name: build


### PR DESCRIPTION
There's no need to run the flint testsuite every time, this will save 1h +.

Also: maybe you want to checkout a particular tag from flint/antic/carat repos. Otherwise, if they push a breaking change your program will stop working since it's always checking out the head.